### PR TITLE
chore(deps): refresh node dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
-    "maven-semantic-release": "github:centralnicgroup-opensource/maven-semantic-release",
+    "maven-semantic-release": "git+https://github.com/centralnicgroup-opensource/maven-semantic-release.git",
     "semantic-release": "^25.0.5",
     "semantic-release-replace-plugin": "github:centralnicgroup-opensource/rtldev-middleware-semantic-release-replace-plugin",
     "semantic-release-teams-notify-plugin": "github:centralnicgroup-opensource/rtldev-middleware-semantic-release-notify-plugin"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ importers:
         specifier: ^10.0.1
         version: 10.0.1(semantic-release@25.0.5)
       maven-semantic-release:
-        specifier: github:centralnicgroup-opensource/maven-semantic-release
+        specifier: git+https://github.com/centralnicgroup-opensource/maven-semantic-release.git
         version: git+https://github.com/centralnicgroup-opensource/maven-semantic-release.git#09376b04661f338924636f8bc96c062ef5086a85(semantic-release@25.0.5)
       semantic-release:
         specifier: ^25.0.5


### PR DESCRIPTION
## Summary
- update package.json with npm-check-updates patch and minor releases
- remove pnpm install state and regenerate pnpm-lock.yaml with pnpm update
- allow the test workflow to enable auto-merge after checks pass